### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -24,7 +24,7 @@ jobs:
       - run: pnpm package
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -30,9 +30,9 @@ jobs:
         with:
           semantic_version: 24
           extra_plugins: |
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/github@8
+            @semantic-release/changelog@6.0.3
+            @semantic-release/git@10.0.1
+            @semantic-release/github@12.0.6
       - name: Push updates to branch for major version
         if: |
           steps.semantic.outputs.new_release_published == 'true' &&

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -13,7 +13,7 @@ jobs:
     concurrency: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v5
         with:
           version: 7.6.0
       - uses: actions/setup-node@v6

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          semantic_version: 19
+          semantic_version: 24
           extra_plugins: |
             @semantic-release/changelog@6
             @semantic-release/git@10

--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -8,7 +8,7 @@ jobs:
     concurrency: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v5
         with:
           version: 7.6.0
       - uses: actions/setup-node@v6
@@ -18,7 +18,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - name: commit linting changes
-        uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: ":robot: pnpm lint [skip ci]"
       - run: pnpm test

--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -8,6 +8,8 @@ jobs:
     concurrency: ${{ github.ref }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
       - uses: pnpm/action-setup@v5
         with:
           version: 7.6.0

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Validate PR Title
-      uses: amannn/action-semantic-pull-request@v5
+      uses: amannn/action-semantic-pull-request@v6
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `amannn/action-semantic-pull-request@v5` → `amannn/action-semantic-pull-request@v6`
- `cycjimmy/semantic-release-action@v3` → `cycjimmy/semantic-release-action@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow dependency bumps, but could affect release/test behavior if the new action major versions change defaults or outputs.
> 
> **Overview**
> Updates CI workflows to newer major versions of key GitHub Actions: `pnpm/action-setup@v5`, `cycjimmy/semantic-release-action@v5` (with `semantic_version: 24` and pinned semantic-release plugins), `stefanzweifel/git-auto-commit-action@v7`, and `amannn/action-semantic-pull-request@v6`.
> 
> Adjusts PR test checkout to explicitly use `ref: ${{ github.head_ref }}` to ensure lint auto-commits apply to the PR branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e12bc3a834d2569628f5e7842d16b7c4565e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->